### PR TITLE
Add into_inner() to retrieve wrapped Read and Write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,11 @@ impl<R: Read, W: Write> TeeReader<R, W> {
             writer: writer,
         }
     }
+
+    /// Consumes the `TeeReader`, returning the wrapped reader and writer.
+    pub fn into_inner(self) -> (R, W) {
+        (self.reader, self.writer)
+    }
 }
 
 impl<R: Read, W: Write> Read for TeeReader<R, W> {


### PR DESCRIPTION
The ability to retrieve the wrapped writer especially is useful. I, for instance, use `TeeReader` write a file to disk while also computing the hash. (For now I tee to the file and write to the hasher but that seems backwards.)

The naming is consistent with [many other APIs](https://doc.rust-lang.org/stable/std/?search=into_inner), e.g. [`BufReader.into_inner`](https://doc.rust-lang.org/stable/std/io/struct.BufReader.html#method.into_inner).

An equivalent method may be useful for your broadcast crate as well. Let me know if you want to keep them aligned, I'd be happy to prepare another PR there.